### PR TITLE
fix documentation URLs forSensio bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ released under the MIT or BSD license.
 Enjoy!
 
 [1]:  http://symfony.com/doc/2.3/book/installation.html
-[6]:  http://symfony.com/doc/2.3/bundles/SensioFrameworkExtraBundle/index.html
+[6]:  http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html
 [7]:  http://symfony.com/doc/2.3/book/doctrine.html
 [8]:  http://symfony.com/doc/2.3/book/templating.html
 [9]:  http://symfony.com/doc/2.3/book/security.html
 [10]: http://symfony.com/doc/2.3/cookbook/email.html
 [11]: http://symfony.com/doc/2.3/cookbook/logging/monolog.html
 [12]: http://symfony.com/doc/2.3/cookbook/assetic/asset_management.html
-[13]: http://symfony.com/doc/2.3/bundles/SensioGeneratorBundle/index.html
+[13]: http://symfony.com/doc/current/bundles/SensioGeneratorBundle/index.html


### PR DESCRIPTION
This fixes #808.
